### PR TITLE
update the priority of conda channels to use conda forge first

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,9 @@
 name: t21-tue-simpeg
 
 channels:
-  - defaults
   - conda-forge
+  - defaults
+
 dependencies:
   - python>=3.6
   - numpy


### PR DESCRIPTION
I had trouble building the environment on my machine using the default channel as the priority, but it built fine with conda forge first, so I interchanged them 